### PR TITLE
pass 1'arg for `reader` to use at launch

### DIFF
--- a/src/reader/main.cpp
+++ b/src/reader/main.cpp
@@ -274,6 +274,15 @@ int main(int argc, char **argv)
     SDL_BlitSurface(screen, NULL, video, NULL);
     SDL_Flip(video);
 
+    bool view_active = false;
+
+    std::string strPath = "";
+    if (argc == 2)
+    {
+        strPath = argv[1]; 
+    }
+    std::filesystem::path pathArg(strPath);
+
     while (!quit)
     {
         bool ran_user_code = task_queue.drain();
@@ -291,6 +300,11 @@ int main(int argc, char **argv)
                         idle_timer.reset();
 
                         SDLKey key = chord_tracker.on_keypress(event.key.keysym.sym);
+
+                        if (argc == 2 && (!std::filesystem::exists(pathArg) || !file_type_is_supported(pathArg)))
+                        {
+                            quit = true;
+                        }
 
                         if (key == SW_BTN_POWER)
                         {

--- a/src/reader/main.cpp
+++ b/src/reader/main.cpp
@@ -334,7 +334,7 @@ int main(int argc, char **argv)
                             {
                                 quit = true;
                             }
-                            else if (argc == 2 && key == SW_BTN_B) 
+                            else if (argc == 2 && (key == SW_BTN_B  || key == SW_BTN_A)) 
                             {
                                 view_active = false;
                             }

--- a/src/reader/main.cpp
+++ b/src/reader/main.cpp
@@ -325,10 +325,18 @@ int main(int argc, char **argv)
                                 {
                                     settings_view->terminate();
                                 }
-                            } 
-                            else if (argc == 2 && key == SW_BTN_B)
+                            }
+                            else if (argc == 2 && key == SW_BTN_SELECT)
+                            {
+                                view_active = !view_active;
+                            }
+                            else if (argc == 2 && key == SW_BTN_B && !view_active && view_stack.top_view() != settings_view)
                             {
                                 quit = true;
+                            }
+                            else if (argc == 2 && key == SW_BTN_B) 
+                            {
+                                view_active = false;
                             }
 
                             ran_user_code = true;

--- a/src/reader/main.cpp
+++ b/src/reader/main.cpp
@@ -79,6 +79,9 @@ void initialize_views(
         fs->set_on_file_focus([&state_store](std::string path) {
             state_store.set_current_browse_path(path);
         });
+        fs->set_on_view_focus([&state_store]() {
+            state_store.remove_current_book_path();
+        });
 
         view_stack.push(fs);
 

--- a/src/reader/view.h
+++ b/src/reader/view.h
@@ -24,6 +24,9 @@ public:
 
     // This view has been popped from the stack (now defunct).
     virtual void on_pop() {}
+
+    // When the view is now on top of the stack.
+    virtual void on_focus() {}
 };
 
 #endif

--- a/src/reader/view_stack.cpp
+++ b/src/reader/view_stack.cpp
@@ -14,9 +14,16 @@ bool ViewStack::render(SDL_Surface *dest, bool force_render)
     bool rendered = false;
     if (!views.empty())
     {
-        if (!views.back()->is_modal())
+        auto &top_view = views.back();
+        if (top_view != last_top_view.lock())
         {
-            rendered = views.back()->render(dest, force_render) || force_render;
+            top_view->on_focus();
+            last_top_view = top_view;
+        }
+
+        if (!top_view->is_modal())
+        {
+            rendered = top_view->render(dest, force_render) || force_render;
         }
         else
         {
@@ -31,7 +38,7 @@ bool ViewStack::render(SDL_Surface *dest, bool force_render)
                 (*it)->render(dest, true);
                 --it;
             }
-            views.back()->render(dest, true);
+            top_view->render(dest, true);
 
             rendered = true;
         }

--- a/src/reader/view_stack.h
+++ b/src/reader/view_stack.h
@@ -9,6 +9,7 @@
 class ViewStack: public View
 {
     std::vector<std::shared_ptr<View>> views;
+    std::weak_ptr<View> last_top_view;
 public:
     void push(std::shared_ptr<View> view);
     virtual ~ViewStack();

--- a/src/reader/views/file_selector.cpp
+++ b/src/reader/views/file_selector.cpp
@@ -15,6 +15,7 @@ struct FSState
     std::vector<FSEntry> path_entries;
     std::function<void(const std::filesystem::path &)> on_file_selected;
     std::function<void(const std::filesystem::path &)> on_file_focus;
+    std::function<void()> on_view_focus;
 
     SelectionMenu menu;
 
@@ -172,6 +173,14 @@ void FileSelector::on_keyheld(SDLKey key, uint32_t held_time_ms)
     state->menu.on_keyheld(key, held_time_ms);
 }
 
+void FileSelector::on_focus()
+{
+    if (state->on_view_focus)
+    {
+        state->on_view_focus();
+    }
+}
+
 void FileSelector::set_on_file_selected(std::function<void(const std::filesystem::path &)> callback)
 {
     state->on_file_selected = callback;
@@ -180,4 +189,9 @@ void FileSelector::set_on_file_selected(std::function<void(const std::filesystem
 void FileSelector::set_on_file_focus(std::function<void(const std::filesystem::path &)> callback)
 {
     state->on_file_focus = callback;
+}
+
+void FileSelector::set_on_view_focus(std::function<void()> callback)
+{
+    state->on_view_focus = callback;
 }

--- a/src/reader/views/file_selector.h
+++ b/src/reader/views/file_selector.h
@@ -26,9 +26,11 @@ public:
     bool is_done() override;
     void on_keypress(SDLKey key) override;
     void on_keyheld(SDLKey key, uint32_t held_time_ms) override;
+    void on_focus() override;
 
     void set_on_file_selected(std::function<void(const std::filesystem::path &)> on_file_selected);
     void set_on_file_focus(std::function<void(const std::filesystem::path &)> on_file_focus);
+    void set_on_view_focus(std::function<void()> on_view_focus);
 };
 
 #endif

--- a/src/reader/views/reader_bootstrap_view.cpp
+++ b/src/reader/views/reader_bootstrap_view.cpp
@@ -73,9 +73,6 @@ void ReaderBootstrapView::load_reader()
     reader_view->set_on_change_address([&state_store, book_id](DocAddr addr) {
         state_store.set_book_address(book_id, addr);
     });
-    reader_view->set_on_quit_requested([&state_store]() {
-        state_store.remove_current_book_path();
-    });
 
     view_stack.push(reader_view);
 }

--- a/src/reader/views/reader_view.cpp
+++ b/src/reader/views/reader_view.cpp
@@ -18,7 +18,6 @@ struct ReaderViewState
 {
     bool is_done = false;
 
-    std::function<void()> on_quit;
     std::function<void(DocAddr)> on_change_address;
 
     std::string filename;
@@ -188,10 +187,6 @@ void ReaderView::on_keypress(SDLKey key)
     if (key == SW_BTN_B)
     {
         state->is_done = true;
-        if (state->on_quit)
-        {
-            state->on_quit();
-        }
         return;
     }
 
@@ -213,11 +208,6 @@ void ReaderView::on_keypress(SDLKey key)
 void ReaderView::on_keyheld(SDLKey key, uint32_t hold_time_ms)
 {
     state->token_view->on_keyheld(key, hold_time_ms);
-}
-
-void ReaderView::set_on_quit_requested(std::function<void()> callback)
-{
-    state->on_quit = callback;
 }
 
 void ReaderView::set_on_change_address(std::function<void(DocAddr)> callback)

--- a/src/reader/views/reader_view.h
+++ b/src/reader/views/reader_view.h
@@ -39,7 +39,6 @@ public:
     void on_keypress(SDLKey key) override;
     void on_keyheld(SDLKey key, uint32_t hold_time_ms) override;
 
-    void set_on_quit_requested(std::function<void()> callback);
     void set_on_change_address(std::function<void(DocAddr)> callback);
 
     void seek_to_toc_index(uint32_t toc_index);


### PR DESCRIPTION
also don't defer to "file_selector" if running with `./reader <file>`, assuming that user is already utilizing some sort of frontend to pick-up a book.

Ideally I would do at L333 in main.cpp smth like:
```c
      else if (argc == 2 && view_stack.top_view() != settings_view \
                 view_stack.top_view() != selection_menu)
      {
          quit = true;
      }
```
but not sure how to implement, so I'm just blocking file_selector with `view_active` variable and by reading inputs. ~~I had to however make use of `SW_BTN_Y` and reassign it for `title_bar`.~~