### PR TITLE
Make font size 40 max for old eyes

### DIFF
--- a/src/reader/config.h
+++ b/src/reader/config.h
@@ -10,7 +10,7 @@
 #define SYSTEM_FONT         "resources/fonts/DejaVuSansMono.ttf"
 
 #define MIN_FONT_SIZE      18
-#define MAX_FONT_SIZE      32
+#define MAX_FONT_SIZE      40
 #define DEFAULT_FONT_SIZE  26
 #define FONT_SIZE_STEP     2
 


### PR DESCRIPTION
My eyes are getting old and the miyoo mini is very small. I made some adjustments to my local instance and thought to throw the change back. 

Before: 
![image](https://github.com/ealang/pixel-reader/assets/398491/1aca66a6-c488-4a9d-a855-5327de4e862e)
![image](https://github.com/ealang/pixel-reader/assets/398491/9b4d9829-5aaf-429b-8d88-0330827f3cf7)

After:
![image](https://github.com/ealang/pixel-reader/assets/398491/443f45dd-2db6-43e6-9da6-a8c524299c73)
![image](https://github.com/ealang/pixel-reader/assets/398491/ab8d85b2-05ca-4ccd-ac06-4689ea7f9d4a)

Its about the max for the settings screen to still be visable. 